### PR TITLE
Add Onfido sandbox to selfie prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ nodemon app.js
 
 Translations are stored in json files in the `locales` directory. Translations are applied to the application using [HMPO i18n](https://github.com/HMPO/hmpo-i18n]). Multiple languages are supported by default using language codes - currently only English translations have been provided during the prototype stage.
 
-
+## Environment Variables
+- `BASE_INFO_API` - Backend service to sign data bundle. (Default to deployment on `PaaS`)
+- `ONFIDO_API_TOKEN` - API token for Onfido API
+- `PORT` - Webserver Port (defaults to `3000`)
+- `REDIS_SESSION_PORT` - Redis Port
+- `REDIS_SESSION_URL` - Redis URL
+- `SESSION_SECRET` - Session secret (dev can use any random string)
 
 # Troubleshooting
 

--- a/app.js
+++ b/app.js
@@ -25,5 +25,8 @@ const { router } = setup({
   dev: true
 });
 
+router.use(/.*upload$/, require("busboy-body-parser")({ limit: "5mb" }));
+
 router.use("/selfie", require("./selfie/router"));
 router.use("/selfie/exif", require("./exif/router"));
+router.use("/selfie/onfido", require("./onfido/router"));

--- a/locales/en/default.yml
+++ b/locales/en/default.yml
@@ -1,6 +1,8 @@
 
 buttons:
   next: Continue
+  documentSubmit: Upload your document
+  photoSubmit: Upload your photo
 govuk:
   serviceName: Prove your identity
   backLink: Back
@@ -8,3 +10,4 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
+

--- a/locales/en/fields.yml
+++ b/locales/en/fields.yml
@@ -34,8 +34,8 @@ expiryDate:
 facialVerificationType:
   legend: " "
   items:
-    onfido:
-      label: Onfido
+    onfidoSandbox:
+      label: Onfido - Sandbox
     idemia:
       label: Idemia
     exif:
@@ -43,3 +43,40 @@ facialVerificationType:
 
 faceFileUpload:
   label: Select a photo to upload
+
+resultType:
+  legend: " "
+  items:
+    clear:
+      label: Clear - No indications of fraud
+    consider:
+      label: Consider ...?
+    caution:
+      label: Caution - Can't complete all verifications, not necessarilty fradulent
+    suspected:
+      label: Suspected - Document shows signs of suspected fraud
+    rejected:
+      label: Rejected - we can't process the image or unsupported document
+
+imageIntegrity:
+  legend: " "
+  items:
+    supportedDocument:
+      label:Unsupported document
+    imageQuality:
+      label: Image Quality
+
+visualAuthenticity:
+  legend: " "
+  items:
+    fonts: Fonts are not correct
+    securityFeatures: Security features have been tampered with
+    faceDetection: No face detected
+
+integrationType:
+  legend: " "
+  items:
+    api:
+      label: Show as GDS style
+    onfido:
+      label: Show as Onfido style

--- a/locales/en/pages.errors.yml
+++ b/locales/en/pages.errors.yml
@@ -1,8 +1,9 @@
 
 error:
-  title: Something went wrong
+  title: Something went wrong!
   content:
     - '{{ error.message }}'
+    - '{{ error | dump }}'
     - '{% if showStack %}<pre>{{error.stack | safe}}</pre>{% endif %}'
 
 pageNotFound:
@@ -11,4 +12,3 @@ pageNotFound:
 sessionEnded:
   title: Session expired
 
-  

--- a/locales/en/pages.yml
+++ b/locales/en/pages.yml
@@ -1,3 +1,70 @@
+onfidoInfo:
+  title: Onfido Sandbox
+  content:
+    - Onfido's Sandbox mode uses predetermined check results and does not do any live processing of data
+    - These predetermined checks are configured the use of special firstName and lastName values
+    - - e.g A surname of "rejected" will return a rejected response
+    - The next few screens ask questions to configure these special names
+    - This data is then sent to Onfido to be run as a check
+
+onfidoName:
+  title: Enter your name
+
+onfidoCheck:
+  title: Checking details
+
+onfidoDocumentUpload:
+  title: Document Upload
+  content:
+    - Upload a copy of your document
+
+onfidoDocumentUploaded:
+  title: Document upload success
+
+onfidoPhotoUpload:
+  title: Photo Upload
+  content:
+    - Upload a recent photo of yourself
+
+onfidoPhotoUploaded:
+  title: Photo upload success
+
+onfidoCheckConfirmed:
+    title: Document and photo have been confirmed
+    content:
+      - - The document has been verified
+      - - The photo has been compared
+      - - The <a href="{{ values.check.resultsUri}}">Onfido report</a> is available to view
+
+onfidoCheckUnconfirmed:
+  title: Document check not confirmed
+  content:
+    - Your document has not been validated
+
+onfidoIntegrationType:
+  title: Onfido Integration Type
+  content:
+    - "Onfido provides two different ways of uploading documents:"
+    - - Direct API access, which will allow us to style things fully in the GDS way
+    - - Web SDK usage, which uses Onfido's file uploading screens
+    - At the end of the file uploading stage, we will still use the direct API to run checks and reports
+
+onfidoGDSStyle:
+  title: GDS Style Integration
+  content:
+    - In this approach this ATP handles all of the document and photo upload reponsiblity
+    - - In production, this would entail proper storage of uploaded files, with deletion policies
+    - - In this demo, everything is saved into the session, which is then saved into Redis
+    - Also only sample documents should be uploaded
+
+onfidoCheckStatus:
+  title: Processing results
+  content:
+    - This page would be a holding page while we wait for Onfido's server to finish processing the document and photo
+    - - In production, Onfido would post to a webhook endpoint that is on our infrastrcture
+    - - In this demo, response times are quick, so we can wait a few seconds on this page
+    - " "
+    - If a result came back needing human assessment, this is the jumping off point from where we would need to do Save & Return
 passportDetails:
   title: Enter your UK passport details
 
@@ -30,3 +97,6 @@ done:
   title: Journey Complete
   content:
     - Journey complete
+
+onfidoResultTypes:
+  title: Result type

--- a/onfido/controllers/document-upload.js
+++ b/onfido/controllers/document-upload.js
@@ -1,0 +1,18 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const debug = require("debug")("selfie:document-upload");
+
+class DocumentUpload extends BaseController {
+  // Multi Part forms have multiple streams of data within the same POST body
+  // busboy-body-parser puts them into req.files
+  // This file data is saved into the sessionModel to be used later
+  process(req, res, next) {
+    if (req.files && req.files["document-file"]) {
+      debug("storeMultiPartFormData: storing in document");
+      req.sessionModel.set("documentData", req.files["document-file"]);
+    }
+
+    super.process(req, res, next);
+  }
+}
+
+module.exports = DocumentUpload;

--- a/onfido/controllers/done.js
+++ b/onfido/controllers/done.js
@@ -1,0 +1,46 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const jwt = require("jsonwebtoken");
+const axios = require("axios");
+
+const backendATP = process.env.BASIC_INFO_API ||
+  "https://di-ipv-generic-atp-service.london.cloudapps.digital/process";
+
+class DoneController extends BaseController {
+  async saveValues(req, res, next) {
+    const validity = (req.sessionModel.get("checkResult") === "clear") ? 4 : 0
+
+    const verificationData = {
+      type: "SELFIE_CHECK",
+      strength: 4,
+      validity: validity,
+      attributes: {
+        // what are the report attributes we want to put in here?
+        // also if it doesn't clear, then what do we want to send back'
+        check: req.sessionModel.get('check')
+      },
+    };
+
+    const { data: output } = await axios.post(backendATP, verificationData);
+    const decoded = jwt.decode(output);
+
+    verificationData.validation = {
+      genericDataVerified: decoded.genericDataVerified,
+    };
+
+    verificationData.jws = output;
+    verificationData.atpResponse = decoded;
+
+    const identityVerification = {
+      type: verificationData.type,
+      verificationData,
+    }
+
+    req.session.sessionData = req.session.sessionData || {};
+    req.session.sessionData.identityVerification = req.session.sessionData.identityVerification || [];
+    req.session.sessionData.identityVerification.push(identityVerification);
+
+    super.saveValues(req, res, next);
+  }
+}
+
+module.exports = DoneController;

--- a/onfido/controllers/exif-display.js
+++ b/onfido/controllers/exif-display.js
@@ -1,0 +1,42 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const exifr = require("exifr");
+
+class ExifDisplayController extends BaseController {
+  async getValues(req, res, next) {
+    req.sessionModel.set(
+      "passportMetadata",
+      await exifr.parse(req.sessionModel.get("passportImage"))
+    );
+    req.sessionModel.set(
+      "uploadedMetadata",
+      await exifr.parse(req.sessionModel.get("uploadedImage"))
+    );
+
+    super.getValues(req, res, next);
+  }
+
+  saveValues(req, res, next) {
+    const passportMetadata = req.sessionModel.get("passportMetadata");
+    const uploadedMetadata = req.sessionModel.get("uploadedMetadata");
+
+    if (
+      !passportMetadata?.ImageDescription ||
+      !uploadedMetadata?.ImageDescription
+    ) {
+      req.sessionModel.set("facialVerification", false);
+    } else if (
+      passportMetadata.ImageDescription !== uploadedMetadata.ImageDescription
+    ) {
+      req.sessionModel.set("facialVerification", false);
+    } else {
+      req.sessionModel.set("facialVerification", true);
+    }
+
+    super.saveValues(req, res, next);
+  }
+
+  compareFaces(req) {
+    return req.sessionModel.get("facialVerification") === true;
+  }
+}
+module.exports = ExifDisplayController;

--- a/onfido/controllers/onfido-check-status.js
+++ b/onfido/controllers/onfido-check-status.js
@@ -1,0 +1,50 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const { Onfido, Region } = require("@onfido/api");
+const debug = require("debug")("selfie:onfido-check");
+
+const onfido = new Onfido({
+  apiToken: process.env.ONFIDO_API_TOKEN,
+  // Supports Region.EU, Region.US and Region.CA
+  region: Region.EU,
+});
+
+
+class OnfidoCheckStatus extends BaseController {
+  async getValues(req, res, next) {
+    try {
+      const check = await onfido.check.find(req.sessionModel.get("checkId"));
+
+      // Check is not pending, or held up
+      if (check.status === "complete") {
+        // No problems with verification
+        if (check.result === "clear") {
+          debug('Check is clear')
+          req.sessionModel.set("checkResult", check.result);
+          req.sessionModel.set("check", check);
+        }
+      }
+      if (check.status !== "in_progress") {
+        req.sessionModel.set("checkResult", check.result);
+        req.sessionModel.set("check", check);
+      }
+
+      debug(req.sessionModel.toJSON());
+      debug(check);
+    } catch (error) {
+      // if (error instanceof OnfidoApiError) {
+      //   // An error response was received from the Onfido API, extra info is available.
+      //   console.log(error.message);
+      //   console.log(error.type);
+      //   console.log(error.isClientError());
+      // } else {
+      // No response was received for some reason e.g. a network error.
+      console.log(error.message);
+      return next(error);
+      // }
+    }
+
+    super.getValues(req, res, next);
+  }
+}
+
+module.exports = OnfidoCheckStatus;

--- a/onfido/controllers/onfido-create-applicant.js
+++ b/onfido/controllers/onfido-create-applicant.js
@@ -1,0 +1,34 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const { Onfido, Region } = require("@onfido/api");
+const debug = require("debug")("selfie:onfido-create-applicant");
+// const PassThrough = require("stream").PassThrough;
+const {PassThrough, Readable} = require('stream')
+
+const onfido = new Onfido({
+  apiToken: process.env.ONFIDO_API_TOKEN,
+  // Supports Region.EU, Region.US and Region.CA
+  region: Region.EU,
+});
+
+class OnfidoCreateApplicantController extends BaseController {
+  async saveValues(req, res, next) {
+    debug('saveValues')
+    try {
+      const applicant = await onfido.applicant.create({
+        firstName: req.sessionModel.get("givenNames"),
+        lastName: req.sessionModel.get("surname"),
+      });
+
+      debug(applicant)
+      req.sessionModel.set('onfidoApplicant', applicant)
+
+    } catch (error) {
+      console.log(error.message);
+      return next(error);
+    }
+
+    super.saveValues(req, res, next);
+  }
+}
+
+module.exports = OnfidoCreateApplicantController;

--- a/onfido/controllers/onfido-start-check.js
+++ b/onfido/controllers/onfido-start-check.js
@@ -1,0 +1,36 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const { Onfido, Region } = require("@onfido/api");
+const debug = require("debug")("selfie:onfido-start-check");
+// const PassThrough = require("stream").PassThrough;
+const {PassThrough, Readable} = require('stream')
+
+const onfido = new Onfido({
+  apiToken: process.env.ONFIDO_API_TOKEN,
+  // Supports Region.EU, Region.US and Region.CA
+  region: Region.EU,
+});
+
+class OnfidoStartCheckController extends BaseController {
+  async saveValues(req, res, next) {
+    const applicant = req.sessionModel.get('onfidoApplicant')
+
+    try {
+      // > The following reports have not been enabled for your account: facial_similarity
+      const check = await onfido.check.create({
+        applicantId: applicant.id,
+        reportNames: ["document", "facial_similarity_photo"],
+      });
+
+      req.sessionModel.set("applicationId", applicant.id);
+      req.sessionModel.set("checkId", check.id);
+
+    } catch (error) {
+      console.log(error.message);
+      return next(error);
+    }
+
+    super.saveValues(req, res, next);
+  }
+}
+
+module.exports = OnfidoStartCheckController;

--- a/onfido/controllers/onfido-upload.js
+++ b/onfido/controllers/onfido-upload.js
@@ -1,0 +1,54 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const { Onfido, Region } = require("@onfido/api");
+const debug = require("debug")("selfie:onfido-upload");
+// const PassThrough = require("stream").PassThrough;
+const {PassThrough, Readable} = require('stream')
+
+const onfido = new Onfido({
+  apiToken: process.env.ONFIDO_API_TOKEN,
+  // Supports Region.EU, Region.US and Region.CA
+  region: Region.EU,
+});
+
+class OnfidoUploadController extends BaseController {
+  async saveValues(req, res, next) {
+    const applicant = req.sessionModel.get('onfidoApplicant')
+    try {
+      const documentData = req.sessionModel.get('documentData')
+
+      const documentBufferStream = new PassThrough();
+      documentBufferStream.end(Buffer.from(documentData.data.data));
+
+      const documentUpload = await onfido.document.upload({
+        applicantId: applicant.id,
+        file: {
+          contents: documentBufferStream,
+          filepath: documentData.name,
+          contentType: documentData.mimetype,
+        },
+        type: "driving_licence",
+      });
+
+      const photoData = req.sessionModel.get('photoData')
+
+      const photoBufferStream = new PassThrough();
+      photoBufferStream.end(Buffer.from(photoData.data.data));
+
+      const photoUpload = await onfido.livePhoto.upload({
+        applicantId: applicant.id,
+        file: {
+          contents: photoBufferStream,
+          filepath: photoData.name,
+          contentType: photoData.mimetype,
+        },
+      })
+    } catch (error) {
+      console.log(error.message);
+      return next(error);
+    }
+
+    super.saveValues(req, res, next);
+  }
+}
+
+module.exports = OnfidoUploadController;

--- a/onfido/controllers/passport-details.js
+++ b/onfido/controllers/passport-details.js
@@ -1,0 +1,27 @@
+const fs = require('fs')
+const path = require('path')
+const passportPath = "./data/passport-page-2020.jpg"
+
+const BaseController = require("hmpo-form-wizard").Controller;
+const DateControllerMixin = require("hmpo-components").mixins.Date;
+
+const DateController = DateControllerMixin(BaseController);
+
+class PassportDetailsController extends DateController {
+// TODO - Make a request to a backend to pretend to validate the passport details
+// What does a passport not found error message look like?
+
+    saveValues(req, res, next) {
+
+        super.saveValues(req, res, () => {
+            const passportImage = fs.readFileSync(passportPath)
+
+            req.sessionModel.set("passportImage", passportImage.toString('base64'))
+
+            next()
+        })
+    }
+
+
+}
+module.exports = PassportDetailsController;

--- a/onfido/controllers/photo-upload.js
+++ b/onfido/controllers/photo-upload.js
@@ -1,0 +1,19 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const debug = require('debug')('selfie:photo-upload')
+
+class PhotoUpload extends BaseController {
+    // Multi Part forms have multiple streams of data within the same POST body
+    // busboy-body-parser puts them into req.files
+    // This file data is saved into the sessionModel to be used later
+    process(req, res, next) {
+        if(req.files && req.files['photo-file']) {
+            debug('storeMultiPartFormData: storing in photo')
+            req.sessionModel.set('photoData', req.files['photo-file'])
+        }
+
+        super.process(req, res, next)
+    }
+
+}
+
+module.exports = PhotoUpload;

--- a/onfido/fields.js
+++ b/onfido/fields.js
@@ -1,0 +1,60 @@
+module.exports = {
+  resultType: {
+    type:"radios",
+    items: [
+        "clear",
+        "consider",
+        "caution",
+        "suspected",
+        "rejected"
+    ]
+  },
+  breakdown: {
+    type: "radios",
+    items: [
+      "imageIntegrity",
+      "visualAuthenticity",
+      "dataValidation",
+      "dataConsistency",
+    ],
+    validate: ["required"],
+  },
+  subBreakdownImageIntegrity: {
+    type: "radios",
+    items: [
+        "supportedDocument",
+        "imageQuality"
+    ],
+    validate: "required"
+  },
+  subBreakdownVisualAuthenticity: {
+    type: "radios",
+    items: [
+      "fonts",
+      "securityFeatures",
+      "faceDetection"
+    ],
+    validate: "required"
+  },
+
+  surname: {
+    type: "text",
+    // validate: ["required"],
+    journeyKey: "surname",
+  },
+  givenNames: {
+    type: "text",
+    // validate: ["required"],
+    journeyKey: "givenNames",
+  },
+  "document-file": {},
+  document: {},
+  livePhoto: {},
+  integrationType: {
+    "type": "radios",
+    items: [
+        "api",
+        "onfido"
+    ]
+  }
+};

--- a/onfido/router.js
+++ b/onfido/router.js
@@ -1,0 +1,41 @@
+const express = require("express");
+const HmpoFormWizard = require("hmpo-form-wizard");
+const debug = require("debug")("selfie:onfido:router");
+
+const path = require('path')
+const steps = require("./steps");
+const fields = require("./fields");
+
+const router = express.Router();
+
+// router.use("/upload", require("busboy-body-parser")({ limit: "5mb" }));
+
+router.use(
+  require("hmpo-form-wizard")(steps, fields, {
+    name: "onfido",
+    journeyName: "ipv",
+    templatePath: "onfido"
+  })
+);
+
+// router.use('/upload', require('busboy-body-parser')({limit: '5mb'}),(req, res,next) => {
+//   debug(Object.keys(req.body))
+//   debug(Object.keys(req.files))
+//   if(!req.files || !req.files.fileUpload) {
+//     debug('No files uploaded')
+//     return res.redirect(req.headers.referer)
+//   }
+//
+//   if(!req.body || !req.body.formFileType) {
+//     debug('No file type specified')
+//     return res.redirect(req.headers.referer)
+//   }
+//
+//   debug(req.files.fileUpload)
+//   req.session['hmpo-wizard-onfido'][req.body.formFileType] = req.files.fileUpload.data.toString('base64')
+//   debug('Onfido File uploaded')
+//
+//   res.redirect(req.body.formReturnPath)
+// })
+
+module.exports = router;

--- a/onfido/steps.js
+++ b/onfido/steps.js
@@ -1,0 +1,148 @@
+const doneController = require("./controllers/done");
+const documentUploadController = require("./controllers/document-upload");
+const photoUploadController = require("./controllers/photo-upload");
+const onfidoStartCheckController = require("./controllers/onfido-start-check");
+const onfidoCheckStatusController = require("./controllers/onfido-check-status");
+const onfidoCreateApplicantController = require("./controllers/onfido-create-applicant");
+const onfidoUploadController = require("./controllers/onfido-upload");
+
+module.exports = {
+  "/": {
+    resetJourney: true,
+    entryPoint: true,
+    skip: true,
+    next: "info",
+  },
+  "/info": {
+    next: "name",
+  },
+  // "/result-types": {
+  //   fields: ["resultType"],
+  //   next: [
+  //     { field: "resultType", value: "clear", next: "name" },
+  //     "breakdown",
+  //   ],
+  // },
+  // "/breakdown": {
+  //   fields: ["breakdown"],
+  //   next: [
+  //     { imageIntegrity: "image-integrity" },
+  //     { visualAuthenticity: "visual-authenticity" },
+  //     "document-upload",
+  //   ],
+  // },
+  "/name": {
+    fields: ["surname", "givenNames"],
+    next: "integration-type",
+  },
+  "/integration-type": {
+    fields: ["integrationType"],
+    next: ["gds-style"],
+  },
+  "/gds-style": {
+    next: "document-upload",
+  },
+  "/document-upload": {
+    controller: documentUploadController,
+    fields: ["document", "document-file"],
+    next: "document-uploaded",
+  },
+  "/document-uploaded": {
+    next: "photo-upload",
+  },
+  "/photo-upload": {
+    entryPoint: true,
+    controller: photoUploadController,
+    next: "photo-uploaded",
+  },
+  "/photo-uploaded": {
+    next: "onfido-create-applicant",
+  },
+  "/onfido-create-applicant": {
+    controller: onfidoCreateApplicantController,
+    skip: true,
+    next: "onfido-upload",
+  },
+  "/onfido-upload": {
+    controller: onfidoUploadController,
+    skip: true,
+    next: "onfido-start-check",
+  },
+  "/onfido-start-check": {
+    skip: true,
+    controller: onfidoStartCheckController,
+    next: "check-status",
+  },
+  "/check-status": {
+    controller: onfidoCheckStatusController,
+    next: [
+      {
+        fn: (req) => req.sessionModel.get("checkResult") === "clear",
+        next: "check-confirmed",
+      },
+      "check-unconfirmed",
+    ],
+  },
+  "/check-confirmed": {
+    next: "done",
+  },
+
+  "/check-unconfirmed": {},
+  "/done": {
+    controller: doneController,
+    skip: true,
+    next: "/ipv/next?source=selfie",
+  },
+  // "/run-check": {
+  //   controller: onfidoRunCheckController
+  // },
+  // "/passport-details": {
+  //   fields: [
+  //     "passportNumber",
+  //     "surname",
+  //     "givenNames",
+  //     "dateOfBirth",
+  //     "issueDate",
+  //     "expiryDate",
+  //   ],
+  //   controller: passportDetails,
+  //   next: "face-upload",
+  // },
+  // "/document-upload": {
+  //   fields: ["documentFileUpload"],
+  //   next: "face-comparison",
+  // },
+  //
+  // "/face-upload": {
+  //   fields: ["faceFileUpload"],
+  //   next: "face-comparison",
+  // },
+  // "/face-uploaded": {
+  //   entryPoint: true,
+  //   skip: true,
+  //   noPost: true,
+  //   next: ["exif-display"],
+  // },
+  // "/exif-display": {
+  //   entryPoint: true,
+  //   controller: exifDisplayController,
+  //   next: [{ fn: "compareFaces", next: "face-match" }, "face-no-match"],
+  // },
+  // "/face-match": {
+  //   entryPoint: true,
+  //   prereq: ["face-comparison", "exif-comparison"],
+  //   next: ["done"],
+  // },
+  // "/face-no-match": {
+  //   entryPoint: true,
+  //   prereqs: ["/selfie/face-comparison"],
+  //   next: ["done"],
+  // },
+  // "/not-available": {},
+  // "/done": {
+  //   controller: doneController,
+  //   entryPoint: true,
+  //   skip: true,
+  //   next: "/ipv/next?source=selfie"
+  // },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@onfido/api": "2.1.0",
         "axios": "0.21.1",
         "busboy-body-parser": "^0.3.2",
         "cfenv": "1.2.4",
@@ -29,6 +30,28 @@
         "node-sass": "^6.0.0",
         "prettier": "2.3.2",
         "uglify-js": "^3.13.8"
+      }
+    },
+    "node_modules/@onfido/api": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@onfido/api/-/api-2.1.0.tgz",
+      "integrity": "sha512-9xsKTtbCB2XcyILwmThO3HvLqsXjf3cnjgTUVblBmUvpIdMs/vM8bSauRHao9cudgRdWBM50nQ7g6sm/C2fGXg==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@onfido/api/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -4489,6 +4512,27 @@
     }
   },
   "dependencies": {
+    "@onfido/api": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@onfido/api/-/api-2.1.0.tgz",
+      "integrity": "sha512-9xsKTtbCB2XcyILwmThO3HvLqsXjf3cnjgTUVblBmUvpIdMs/vM8bSauRHao9cudgRdWBM50nQ7g6sm/C2fGXg==",
+      "requires": {
+        "axios": "^0.21.1",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@onfido/api": "2.1.0",
     "axios": "0.21.1",
     "busboy-body-parser": "^0.3.2",
     "cfenv": "1.2.4",

--- a/selfie/fields.js
+++ b/selfie/fields.js
@@ -30,7 +30,7 @@ module.exports = {
   },
   facialVerificationType: {
     type: "radios",
-    items: ["exif", "onfido","idemia"],
+    items: ["exif", "onfidoSandbox","idemia"],
     validate: ["required"],
   },
   faceFileUpload: {

--- a/selfie/steps.js
+++ b/selfie/steps.js
@@ -10,6 +10,7 @@ module.exports = {
     fields: ["facialVerificationType"],
     next: [
       { field: "facialVerificationType", value: "exif", next: "/selfie/exif" },
+      { field: "facialVerificationType", value: "onfidoSandbox", next: "/selfie/onfido" },
       "not-available",
     ],
   },

--- a/views/exif/face-upload.html
+++ b/views/exif/face-upload.html
@@ -15,15 +15,15 @@
     <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}" />
     {%- endif %}
 
-{{ govukFileUpload({
-id: "faceFileUpload",
-name: "faceFileUpload",
-label: {
-text: "Upload a file"
-}
-}) }}
+    {{ govukFileUpload({
+        id: "faceFileUpload",
+        name: "faceFileUpload",
+        label: {
+        text: "Upload a file"
+        }
+    }) }}
 
-{{ hmpoSubmit(ctx) }}
+    {{ hmpoSubmit(ctx) }}
 
 </form>
 {% endblock %}

--- a/views/onfido/breakdown.html
+++ b/views/onfido/breakdown.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoBreakdown" %}

--- a/views/onfido/check-confirmed.html
+++ b/views/onfido/check-confirmed.html
@@ -1,0 +1,10 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoCheckConfirmed" %}
+
+{% block innerContent %}
+
+<div>{{ values.check | dump }}</div>
+
+{{ super () }}
+
+{% endblock %}

--- a/views/onfido/check-status.html
+++ b/views/onfido/check-status.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoCheckStatus" %}

--- a/views/onfido/check-unconfirmed.html
+++ b/views/onfido/check-unconfirmed.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoCheckUnconfirmed" %}

--- a/views/onfido/check.html
+++ b/views/onfido/check.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoCheck" %}

--- a/views/onfido/document-upload.html
+++ b/views/onfido/document-upload.html
@@ -1,0 +1,68 @@
+{% extends "form-template.njk" %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
+{% set hmpoTitle %}Upload your document{% endset %}
+
+{% block mainContent %}
+<h1>{{ hmpoTitle }}</h1>
+
+<ul class="govuk-list govuk-list--bullet">
+    <li>This page is used to represent what a user would see</li>
+    <li>Onfido in Sandbox mode will not process this image at all</li>
+    <li>Do not upload personal documents to the sandbox environment</li>
+</ul>
+
+<form
+        enctype="multipart/form-data"
+        method="POST"
+        novalidate="true">
+    {%- set csrfToken = ctx("csrf-token") %}
+    {%- if csrfToken %}
+    <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}" />
+    {%- endif %}
+
+    {# TODO: Add logic for `mobileDevice` #}
+
+{{ govukFileUpload({
+  id: "document",
+  classes: "document-choose-file",
+  label: {
+    attributes: { id: "document-label" },
+    text: translate("buttons.documentSubmitMobile") if mobileDevice else translate("buttons.documentSubmit")
+  },
+  attributes: {
+    accept: "image/jpeg"
+  }
+}) }}
+
+<input type="hidden" name="document-filename" id="document-filename"/>
+
+
+{{ hmpoSubmit(ctx, { id: "document-submit-button" }) }}
+
+<script>
+    (function() {
+        // auto-submit when a file is selected
+        var button = document.getElementById("document-label");
+
+        var file = document.getElementById("document");
+        var filename = document.getElementById("document-filename");
+        var submit = document.getElementById("document-submit-button");
+        file.onchange = function() {
+            filename.name = "document";
+            filename.value = file.value;
+            file.name = "document-file"
+
+            // file.value = "";
+            submit.click();
+            submit.disabled = true;
+        };
+        // hide submit button, file upload, and make upload label look like a submit button
+        file.className = file.className + " govuk-visually-hidden";
+        submit.className = submit.className + " govuk-visually-hidden";
+        button.className = button.className + " govuk-button document-button";
+    })();
+</script>
+
+</form>
+{% endblock %}

--- a/views/onfido/document-uploaded.html
+++ b/views/onfido/document-uploaded.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoDocumentUploaded" %}

--- a/views/onfido/gds-style.html
+++ b/views/onfido/gds-style.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoGDSStyle" %}

--- a/views/onfido/info.html
+++ b/views/onfido/info.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoInfo" %}

--- a/views/onfido/integration-type.html
+++ b/views/onfido/integration-type.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoIntegrationType" %}

--- a/views/onfido/name.html
+++ b/views/onfido/name.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoName" %}

--- a/views/onfido/photo-upload.html
+++ b/views/onfido/photo-upload.html
@@ -1,0 +1,67 @@
+{% extends "form-template.njk" %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
+{% set hmpoTitle %}Upload your live photo{% endset %}
+
+{% block mainContent %}
+<h1>{{ hmpoTitle }}</h1>
+
+<ul class="govuk-list govuk-list--bullet">
+    <li>This page is used to represent what a user would see</li>
+    <li>Onfido in Sandbox mode will not process this image at all</li>
+    <li>Do not upload personal documents to the sandbox environment</li>
+</ul>
+
+
+<form
+        enctype="multipart/form-data"
+        method="POST"
+        novalidate="true">
+    {%- set csrfToken = ctx("csrf-token") %}
+    {%- if csrfToken %}
+    <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}" />
+    {%- endif %}
+
+    {# TODO: Add logic for `mobileDevice` #}
+
+    {{ govukFileUpload({
+    id: "document",
+    classes: "photo-choose-file",
+    label: {
+    attributes: { id: "photo-label" },
+    text: translate("buttons.photoSubmitMobile") if mobileDevice else translate("buttons.photoSubmit")
+    },
+    attributes: {
+    accept: "image/jpeg"
+    }
+    }) }}
+
+    <input type="hidden" name="photo-filename" id="photo-filename"/>
+
+
+    {{ hmpoSubmit(ctx, { id: "photo-submit-button" }) }}
+
+    <script>
+        (function() {
+            // auto-submit when a file is selected
+            var button = document.getElementById("photo-label");
+
+            var file = document.getElementById("document");
+            var filename = document.getElementById("photo-filename");
+            var submit = document.getElementById("photo-submit-button");
+            file.onchange = function() {
+                filename.name = "document";
+                filename.value = file.value;
+                file.name = "photo-file"
+                // file.value = "";
+                submit.click();
+            };
+            // hide submit button, file upload, and make upload label look like a submit button
+            file.className = file.className + " govuk-visually-hidden";
+            submit.className = submit.className + " govuk-visually-hidden";
+            button.className = button.className + " govuk-button photo-button";
+        })();
+    </script>
+
+</form>
+{% endblock %}

--- a/views/onfido/photo-uploaded.html
+++ b/views/onfido/photo-uploaded.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoPhotoUploaded" %}

--- a/views/onfido/result-types.html
+++ b/views/onfido/result-types.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoResultTypes" %}

--- a/views/onfido/run-check.html
+++ b/views/onfido/run-check.html
@@ -1,0 +1,2 @@
+{% extends "form-template.njk" %}
+{% set hmpoPageKey = "onfidoRunCheck" %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Use Onfido API with GDS styling to perform a document and likeness check.

Note: Although there are a lot of files in this PR, they're mostly localisation and page setup, the form framework handles most of the work, so there is very little application code to be reviewed.

### What changed

- Added an Onfido sub-router & form-wizard
- Added "clear" path through Onfido  system
- Fixed uploading files using busboy
- Return signed packet of Onfido data to selfie endpoint
   
<!-- Describe the changes in detail - the "what"-->

### Why did it change

- We want to test out the Onfido API
- 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-179](https://govukverify.atlassian.net/browse/PYI-179)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
