### PR TITLE
fix: Retry Redis connection on startup

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -19,5 +19,23 @@ module.exports = () => {
 
   return {
     connectionString: `${scheme}://${host}:${port}`,
+    retry_strategy: function (options) {
+      if (options.error && options.error.code === "ECONNREFUSED") {
+        // End reconnecting on a specific error and flush all commands with
+        // a individual error
+        return new Error("The server refused the connection");
+      }
+      if (options.total_retry_time > 1000 * 60 * 60) {
+        // End reconnecting after a specific timeout and flush all commands
+        // with a individual error
+        return new Error("Retry time exhausted");
+      }
+      if (options.attempt > 10) {
+        // End reconnecting with built in error
+        return undefined;
+      }
+      // reconnect after
+      return Math.min(options.attempt * 100, 3000);
+    },
   };
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

HMPO-App starts up quicker than Redis does on first initialisation,
which causes an error.

This adds a multiple retry attempt on connection, which also fits with
12 factor style applications

This `retry_strategy` function was copied out of the latest relevant version of the [Node Redis Client](https://github.com/NodeRedis/node-redis/tree/4f85030e42da2eed6a178e54994330af5062761e)

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-XXXX]()

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
